### PR TITLE
Use replaceCurrentItem to allow playing different audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Flutter audio plugin.
   - [x] play (remote and local file)
   - [x] stop
   - [x] pause
+  - [x] seek
   - [x] onComplete
   - [x] onDuration / onCurrentPosition
 
@@ -40,7 +41,7 @@ AudioPlayer audioPlayer = new AudioPlayer();
 //...
 ```
 
-### play, pause , stop
+### play, pause , stop, seek
 
 ```dart
 play() async {
@@ -64,6 +65,9 @@ stop() async {
   final result = await audioPlayer.stop();
   if (result == 1) setState(() => playerState = PlayerState.stopped);
 }
+
+// seek 5 seconds from the beginning
+audioPlayer.seek(5.0);
 
 ```
 

--- a/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
+++ b/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
@@ -49,16 +49,26 @@ public class AudioplayerPlugin implements MethodCallHandler {
     } else if (call.method.equals("stop")) {
       stop();
       response.success(1);
+    } else if (call.method.equals("seek")) {
+      double position = call.arguments();
+      seek(position);
+      response.success(1);
     } else {
       response.notImplemented();
     }
   }
 
+  private void seek(double position) {
+    mediaPlayer.seekTo((int) (position * 1000));
+  }
+
   private void stop() {
     handler.removeCallbacks(sendData);
-    mediaPlayer.stop();
-    mediaPlayer.release();
-    mediaPlayer = null;
+    if (mediaPlayer != null) {
+      mediaPlayer.stop();
+      mediaPlayer.release();
+      mediaPlayer = null;
+    }
   }
 
   private void pause() {

--- a/ios/Classes/SwiftAudioplayerPlugin.swift
+++ b/ios/Classes/SwiftAudioplayerPlugin.swift
@@ -48,6 +48,12 @@ public class SwiftAudioplayerPlugin: NSObject, FlutterPlugin {
         pause()
     case "stop":
         stop()
+    case "seek":
+        guard let sec:Double = call.arguments as? Double else {
+            result(0)
+            return
+        }
+        seek(sec)
     default:
         result(FlutterMethodNotImplemented)
     }
@@ -123,6 +129,11 @@ public class SwiftAudioplayerPlugin: NSObject, FlutterPlugin {
             isPlaying = false
             print("stop")
         }
+    }
+
+    func seek(_ seconds: Double) {
+        let time = CMTime.init(seconds: seconds, preferredTimescale: 1);
+        playerItem?.seek(to: time);
     }
     
     func onSoundComplete(note: Notification) {

--- a/lib/audioplayer.dart
+++ b/lib/audioplayer.dart
@@ -30,6 +30,8 @@ class AudioPlayer {
 
   Future<int> stop() => _channel.invokeMethod('stop');
 
+  Future<int> seek(double seconds) => _channel.invokeMethod('seek', seconds);
+
   void setDurationHandler(TimeChangeHandler handler) {
     durationHandler = handler;
   }


### PR DESCRIPTION
On iOS, I could not play different sound files one after the other; it would always play just the one. I figured out that you need to call `replaceCurrentItem` so the player object can get a new player item when the URL changes.