### PR TITLE
Added better error message for onError for iOS

### DIFF
--- a/ios/Classes/AudioplayerPlugin.m
+++ b/ios/Classes/AudioplayerPlugin.m
@@ -226,7 +226,7 @@ FlutterMethodChannel *_channel;
     if ([[player currentItem] status ] == AVPlayerItemStatusReadyToPlay) {
       [self updateDuration];
     } else if ([[player currentItem] status ] == AVPlayerItemStatusFailed) {
-      [_channel invokeMethod:@"audio.onError" arguments:@"AVPlayerItemStatus.failed" ];
+      [_channel invokeMethod:@"audio.onError" arguments:@[(player.currentItem.error.localizedDescription)] ];
     }
   } else {
     // Any unrecognized context must belong to super


### PR DESCRIPTION
Get the underlying player's error information instead of the generic status failure.

https://developer.apple.com/documentation/avfoundation/avplayeritem/1389185-error