### PR TITLE
Add getVolume and setVolume for Android and iOS

### DIFF
--- a/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
+++ b/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
@@ -91,6 +91,7 @@ public class AudioplayerPlugin implements MethodCallHandler {
 
   private int getVolume() {
 /*
+    //TODO: Replace volume getter with this logic to normalize to 0 to 100
     int maxVolume = getStreamMaxVolume(AudioManager.STREAM_MUSIC);
     int minVolume = getStreamMinVolume(AudioManager.STREAM_MUSIC);
     int volume = (am.getStreamVolume(AudioManager.STREAM_MUSIC) - minVolume) * 100 / (maxVolume - minVolume);
@@ -101,6 +102,7 @@ public class AudioplayerPlugin implements MethodCallHandler {
 
   private void setVolume(int volume) {
 /*
+    //TODO: Replace volume setter with this logic to normalize to 0 to 100
     int maxVolume = getStreamMaxVolume(AudioManager.STREAM_MUSIC);
     int minVolume = getStreamMinVolume(AudioManager.STREAM_MUSIC);
     int index = volume * (maxVolume - minVolume) / 100 + minVolume;

--- a/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
+++ b/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
@@ -67,9 +67,13 @@ public class AudioplayerPlugin implements MethodCallHandler {
         mute(muted);
         response.success(null);
         break;
+      case "getVolume":
+        int volume = getVolume();
+        response.success(volume);
+        break;
       case "setVolume":
-        int volume = call.arguments();
-        setVolume(volume);
+        int volumeToSet = call.arguments();
+        setVolume(volumeToSet);
         response.success(null);
         break;
       default:
@@ -85,8 +89,24 @@ public class AudioplayerPlugin implements MethodCallHandler {
     }
   }
 
+  private int getVolume() {
+/*
+    int maxVolume = getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+    int minVolume = getStreamMinVolume(AudioManager.STREAM_MUSIC);
+    int volume = (am.getStreamVolume(AudioManager.STREAM_MUSIC) - minVolume) * 100 / (maxVolume - minVolume);
+*/
+    int volume = am.getStreamVolume(AudioManager.STREAM_MUSIC);
+    return volume;
+  }
+
   private void setVolume(int volume) {
-    am.setStreamVolume(AudioManager.STREAM_MUSIC, volume, 0);
+/*
+    int maxVolume = getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+    int minVolume = getStreamMinVolume(AudioManager.STREAM_MUSIC);
+    int index = volume * (maxVolume - minVolume) / 100 + minVolume;
+*/
+    int index = volume;
+    am.setStreamVolume(AudioManager.STREAM_MUSIC, index, 0);
   }
 
   private void seek(double position) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,7 @@ class AudioApp extends StatefulWidget {
 class _AudioAppState extends State<AudioApp> {
   Duration duration;
   Duration position;
+  int _volume;
 
   AudioPlayer audioPlayer;
 
@@ -50,6 +51,9 @@ class _AudioAppState extends State<AudioApp> {
   void initState() {
     super.initState();
     initAudioPlayer();
+    audioPlayer.getVolume().then((volume) {
+      _volume = volume;
+    });
   }
 
   @override
@@ -218,6 +222,25 @@ class _AudioAppState extends State<AudioApp> {
                 onPressed: () => mute(false),
                 icon: new Icon(Icons.headset),
                 color: Colors.cyan),
+          ],
+        ),
+        new Row (
+          children: <Widget>[
+            new Icon(Icons.volume_down),
+            new Expanded(child:
+              new Slider(
+                min: 0.0,
+                max: 100.0,
+                value: _volume?.toDouble() ?? 50.0,
+                onChanged: (double newValue) {
+                  setState(() {
+                    _volume = newValue.toInt();
+                  });
+                  audioPlayer.setVolume(_volume);
+                },
+              ),
+            ),
+            new Icon(Icons.volume_up),
           ],
         ),
         new Row(mainAxisSize: MainAxisSize.min, children: [

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -211,6 +211,28 @@ class _AudioAppState extends State<AudioApp> {
                     audioPlayer.seek((value / 1000).roundToDouble()),
                 min: 0.0,
                 max: duration.inMilliseconds.toDouble()),
+        new Row(mainAxisSize: MainAxisSize.min, children: [
+          new Padding(
+              padding: new EdgeInsets.all(12.0),
+              child: new Stack(children: [
+                new CircularProgressIndicator(
+                    value: 1.0,
+                    valueColor: new AlwaysStoppedAnimation(Colors.grey[300])),
+                new CircularProgressIndicator(
+                  value: position != null && position.inMilliseconds > 0
+                      ? (position?.inMilliseconds?.toDouble() ?? 0.0) /
+                      (duration?.inMilliseconds?.toDouble() ?? 0.0)
+                      : 0.0,
+                  valueColor: new AlwaysStoppedAnimation(Colors.cyan),
+                  backgroundColor: Colors.yellow,
+                ),
+              ])),
+          new Text(
+              position != null
+                  ? "${positionText ?? ''} / ${durationText ?? ''}"
+                  : duration != null ? durationText : '',
+              style: new TextStyle(fontSize: 24.0))
+        ]),
         new Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
@@ -243,27 +265,5 @@ class _AudioAppState extends State<AudioApp> {
             new Icon(Icons.volume_up),
           ],
         ),
-        new Row(mainAxisSize: MainAxisSize.min, children: [
-          new Padding(
-              padding: new EdgeInsets.all(12.0),
-              child: new Stack(children: [
-                new CircularProgressIndicator(
-                    value: 1.0,
-                    valueColor: new AlwaysStoppedAnimation(Colors.grey[300])),
-                new CircularProgressIndicator(
-                  value: position != null && position.inMilliseconds > 0
-                      ? (position?.inMilliseconds?.toDouble() ?? 0.0) /
-                          (duration?.inMilliseconds?.toDouble() ?? 0.0)
-                      : 0.0,
-                  valueColor: new AlwaysStoppedAnimation(Colors.cyan),
-                  backgroundColor: Colors.yellow,
-                ),
-              ])),
-          new Text(
-              position != null
-                  ? "${positionText ?? ''} / ${durationText ?? ''}"
-                  : duration != null ? durationText : '',
-              style: new TextStyle(fontSize: 24.0))
-        ])
       ]));
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,9 +51,6 @@ class _AudioAppState extends State<AudioApp> {
   void initState() {
     super.initState();
     initAudioPlayer();
-    audioPlayer.getVolume().then((volume) {
-      _volume = volume;
-    });
   }
 
   @override
@@ -92,6 +89,11 @@ class _AudioAppState extends State<AudioApp> {
     await audioPlayer.play(kUrl);
     setState(() {
       playerState = PlayerState.playing;
+    });
+    audioPlayer.getVolume().then((volume) {
+      setState(() {
+        _volume = volume;
+      });
     });
   }
 

--- a/ios/Classes/AudioplayerPlugin.m
+++ b/ios/Classes/AudioplayerPlugin.m
@@ -12,6 +12,8 @@ static AVPlayerItem *playerItem;
 -(void)pause;
 -(void)stop;
 -(void)mute:(BOOL)muted;
+-(NSNumber *)getVolume;
+-(void)setVolume:(int)volume;
 -(void)seek:(CMTime)time;
 -(void)onStart;
 -(void)onTimeInterval:(CMTime)time;
@@ -59,6 +61,16 @@ FlutterMethodChannel *_channel;
                             @"mute":
                               ^{
                                 [self mute:[call.arguments boolValue]];
+                                result(nil);
+                              },
+                            @"getVolume":
+                              ^{
+                                NSNumber *volumeRef = [self getVolume];
+                                result(volumeRef);
+                              },
+                            @"setVolume":
+                              ^{
+                                [self setVolume:[call.arguments intValue]];
                                 result(nil);
                               },
                             @"seek":
@@ -157,6 +169,16 @@ FlutterMethodChannel *_channel;
 
 - (void)mute:(bool)muted {
   player.muted = muted;
+}
+
+- (NSNumber *)getVolume {
+    int volume = (int)roundf(player.volume * 100.0);
+    NSNumber *volumeRef = [NSNumber numberWithInt:volume];
+    return volumeRef;
+}
+
+- (void)setVolume:(int)volume {
+  player.volume = (float)volume / 100.0;
 }
 
 - (void)seek:(CMTime)time {

--- a/lib/audioplayer.dart
+++ b/lib/audioplayer.dart
@@ -55,7 +55,10 @@ class AudioPlayer {
   /// Mute sound.
   Future<void> mute(bool muted) async => await _channel.invokeMethod('mute', muted);
 
-  /// Set playing volume.
+  /// Set playing volume. Normalized integer range of 0 to 100.
+  Future<int> getVolume() async => await _channel.invokeMethod('getVolume');
+
+  /// Set playing volume. Normalized integer range of 0 to 100.
   Future<void> setVolume(int volume) async => await _channel.invokeMethod('setVolume', volume);
 
   /// Seek to a specific position in the audio stream.

--- a/lib/audioplayer.dart
+++ b/lib/audioplayer.dart
@@ -55,7 +55,7 @@ class AudioPlayer {
   /// Mute sound.
   Future<void> mute(bool muted) async => await _channel.invokeMethod('mute', muted);
 
-  /// Set playing volume. Normalized integer range of 0 to 100.
+  /// Get playing volume. Normalized integer range of 0 to 100.
   Future<int> getVolume() async => await _channel.invokeMethod('getVolume');
 
   /// Set playing volume. Normalized integer range of 0 to 100.


### PR DESCRIPTION
I took the fork started by [klinki](https://github.com/klinki) to implement setVolume on Android, brought it current and then added getVolume. Also implemented both of these for iOS.

Since iOS uses a double from 0.0 to 1.0 for volume and Android uses a varying range of integers, I tried to normalize to 0 to 100 for all platforms. However, I am not an Android developer and I had trouble getting the functions for reading min and max volume on Android to work. So I commented that code out. It is still useful as is. But I think it would be better if the normalization worked in case someone more familiar with building for Android can get those to work.