### PR TITLE
Audio output for speakers now supported on iOS

### DIFF
--- a/ios/Classes/AudioplayerPlugin.m
+++ b/ios/Classes/AudioplayerPlugin.m
@@ -77,6 +77,18 @@ FlutterMethodChannel *_channel;
 }
 
 - (void)play:(NSString*)url isLocal:(int)isLocal {
+  
+  	// Fix for iOS Speaker Output
+        NSError *error = nil;
+        BOOL success = [[AVAudioSession sharedInstance]
+                        setCategory:AVAudioSessionCategoryPlayback
+                        error:&error];
+        if (!success) {
+            NSLog(@"Error setting speaker");
+            
+        }
+	// End fix
+
   if (![url isEqualToString:lastUrl]) {
     [playerItem removeObserver:self
                     forKeyPath:@"player.currentItem.status"];


### PR DESCRIPTION
The plugin was not outputting sound in speakers on iOS devices we tested on.
Then @takaoandrew proposed a fix in the issue #36.

I added it and it's now working as expected.