### PR TITLE
Cleanup java warnings. Update Dart SDK requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+- Allow Dart 2 SDK
+- Fix java lint warnings.
+
 ## 0.5.0
 - BREAKING Change: No more separate handlers for communicating the state of the player. Instead we rely on streams to publish state changes and position updates.
 - Code formatting and flow improvements. Preparation for testing.

--- a/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
+++ b/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
@@ -4,7 +4,6 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.os.Handler;
 import android.util.Log;
-import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -24,7 +23,6 @@ public class AudioplayerPlugin implements MethodCallHandler {
   private static final String ID = "bz.rxla.flutter/audio";
 
   private final MethodChannel channel;
-  private final Registrar registrar;
   private final AudioManager am;
   private final Handler handler = new Handler();
   private MediaPlayer mediaPlayer;
@@ -35,7 +33,6 @@ public class AudioplayerPlugin implements MethodCallHandler {
   }
 
   private AudioplayerPlugin(Registrar registrar, MethodChannel channel) {
-    this.registrar = registrar;
     this.channel = channel;
     channel.setMethodCallHandler(this);
     Context context = registrar.context().getApplicationContext();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.19.0 <2.0.0"
+    sdk: ">=1.19.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audioplayer
 description: A flutter plugin to play audio files
-version: 0.5.0
+version: 0.5.1
 author: Erick Ghaumez <erick@rxla.bz>
 homepage: https://github.com/rxlabz/audioplayer
 


### PR DESCRIPTION
- Registrar is never read in the body of the class, just during init.
- FlutterActivity is never used.