### PR TITLE
Add playback speed control

### DIFF
--- a/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
+++ b/android/src/main/java/bz/rxla/audioplayer/AudioplayerPlugin.java
@@ -64,6 +64,11 @@ public class AudioplayerPlugin implements MethodCallHandler {
         mute(muted);
         response.success(null);
         break;
+      case "changeSpeed":
+        double value = call.arguments();
+        changeSpeed(value);
+        response.success(null);
+        break;
       default:
         response.notImplemented();
     }
@@ -89,6 +94,14 @@ public class AudioplayerPlugin implements MethodCallHandler {
       mediaPlayer = null;
       channel.invokeMethod("audio.onStop", null);
     }
+  }
+
+  private void changeSpeed(double value){
+    handler.removeCallbacks(sendData);
+    if (mediaPlayer != null && android.os.Build.VERSION.SDK_INT>23) {
+      mediaPlayer.setPlaybackParams(mediaPlayer.getPlaybackParams().setSpeed((float) value));
+    }
+
   }
 
   private void pause() {

--- a/ios/Classes/AudioplayerPlugin.m
+++ b/ios/Classes/AudioplayerPlugin.m
@@ -65,6 +65,11 @@ FlutterMethodChannel *_channel;
                                   ^{
                                       [self seek:CMTimeMakeWithSeconds([call.arguments doubleValue], 1)];
                                       result(nil);
+                                  },
+                              @"changeSpeed":
+                                  ^{
+                                      [self changeSpeed:[call.arguments doubleValue]];
+                                      result(nil);
                                   }
                               };
     
@@ -144,6 +149,11 @@ FlutterMethodChannel *_channel;
     [player pause];
     isPlaying = false;
     [_channel invokeMethod:@"audio.onPause" arguments:nil];
+}
+
+- (void)changeSpeed:(doubleValue) speed {
+    player.rate = speed;
+    [_channel invokeMethod:@"audio.onSpeed" arguments:@((float) speed)];
 }
 
 - (void)stop {

--- a/lib/audioplayer.dart
+++ b/lib/audioplayer.dart
@@ -52,6 +52,9 @@ class AudioPlayer {
   /// Stop the currently playing stream.
   Future<void> stop() async => await _channel.invokeMethod('stop');
 
+  /// Changes audio playback speed
+  Future<void> changeSpeed(double value) async => await _channel.invokeMethod('changeSpeed', value);
+
   /// Mute sound.
   Future<void> mute(bool muted) async => await _channel.invokeMethod('mute', muted);
 


### PR DESCRIPTION
Add `changeSpeed` method to control playback speed
on iOS and Android devices with SDK level > 23.

There were requests in issues #71 and #13 