### PR TITLE
fix bugs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,16 +3,18 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
@@ -20,8 +22,8 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
```
* What went wrong:
A problem occurred configuring root project 'audioplayer'.
> No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android

```

fix this bug