### PR TITLE
Compatibility with newer gradle versions

### DIFF
--- a/audioplayer/android/build.gradle
+++ b/audioplayer/android/build.gradle
@@ -24,6 +24,8 @@ android {
     buildToolsVersion '25.0.3'
 
     defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 25
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/audioplayer/android/src/main/AndroidManifest.xml
+++ b/audioplayer/android/src/main/AndroidManifest.xml
@@ -2,6 +2,4 @@
   package="bz.rxla.audioplayer"
   android:versionCode="1"
   android:versionName="0.1.0">
-
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 </manifest>


### PR DESCRIPTION
`The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file`

Newer gradle version do not support uses-sdk tag inside AndroidManifest.xml anymore.

Needs to be moved to build.gradle.