### PR TITLE
Fix exception thrown on infinite audio duration

### DIFF
--- a/audioplayer_web/lib/audioplayer_web.dart
+++ b/audioplayer_web/lib/audioplayer_web.dart
@@ -88,7 +88,8 @@ class AudioplayerPlugin {
       channel.invokeMethod("audio.onComplete");
     });
     durationWatcher = player.onDurationChange.listen((event) {
-      channel.invokeMethod("audio.onStart", (player.duration * 1000).toInt());
+      final duration = player.duration != double.infinity ? player.duration : 0;
+      channel.invokeMethod("audio.onStart", (duration * 1000).toInt());
     });
     progressWatcher = player.onTimeUpdate.listen((event) {
       channel.invokeMethod(


### PR DESCRIPTION
Got this exception while trying to load audio from a backend that stream mp3 audio with unknown duration.

![exception](https://user-images.githubusercontent.com/10296472/82557354-c671ca80-9b95-11ea-9298-b01657290c41.png)
