### PR TITLE
Put currentUrl into /assets/ folder to fix bug with production build

### DIFF
--- a/audioplayer_web/lib/audioplayer_web.dart
+++ b/audioplayer_web/lib/audioplayer_web.dart
@@ -49,7 +49,7 @@ class AudioplayerPlugin {
         }
         currentUrl = url;
         try {
-          _play(currentUrl);
+          _play('assets/$currentUrl');
         } catch (err) {
           print('Audioplayer error : $err');
           return 0;


### PR DESCRIPTION
I've added 'assets/' path in the `currentUrl` and now it's possible to build your project with 'flutter build web' and it will work without any path issues with the assets folder.
It's also work in development mode as before without any issues