### PR TITLE
Add key for reusing in stateful widgets.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,11 @@ void main() {
 enum PlayerState { stopped, playing, paused }
 
 class AudioApp extends StatefulWidget {
+  
+  const AudioApp({
+    Key key,
+  }) : super(key: key);
+  
   @override
   _AudioAppState createState() => _AudioAppState();
 }


### PR DESCRIPTION
Makes it possible to use this stateful widget as `AudioApp(key: UniqueKey());` is other Stateful widgets

example build method of stateful widget:

```
@override
  Widget build(BuildContext context) {
    return Column(
      children: <Widget>[
          AudioApp(key: UniqueKey());
      ],
    );
  }
```